### PR TITLE
Fix System.ArgumentException

### DIFF
--- a/csharp/csharp/Program.cs
+++ b/csharp/csharp/Program.cs
@@ -3,11 +3,9 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 
-// Using RingCentralSdk 0.1.21
+// Using RingCentralSdk 1.0.0 branch
 using RingCentral;
-using RingCentral.SDK;
-using RingCentral.SDK.Helper;
-using RingCentral.SDK.Http;
+using RingCentral.Http;
 
 using DotEnv;
 using HandlebarsDotNet;
@@ -26,7 +24,7 @@ namespace csharp
 			var appName = "Custom Fax Cover Page Text";
 			var appVersion = "0.0.1";
 			var sdk = new SDK(appKey, appSecret, serverUrl, appName, appVersion);
-			Response response = sdk.GetPlatform().Authorize(username, extension, password, true);
+			sdk.Platform.Login(username, extension, password, true);
 			return sdk;
 		}
 
@@ -54,7 +52,7 @@ namespace csharp
 			return coverPage;
 		}
 
-		public static void SendFax(RingCentral.SDK.SDK sdk) {
+		public static void SendFax(SDK sdk) {
 			// Get Cover Page
 			var coverPage = GetCoverPage ();
 
@@ -71,8 +69,7 @@ namespace csharp
 
 			var request = new Request ("/restapi/v1.0/account/~/extension/~/fax", json, attachments);
 
-			var html = request.GetHttpContent ();
-			var response = sdk.GetPlatform().Post(request);
+			sdk.Platform.Post(request);
 		}
 
 		public static void Main (string[] args)

--- a/csharp/csharp/csharp.csproj
+++ b/csharp/csharp/csharp.csproj
@@ -40,39 +40,37 @@
     <Reference Include="Handlebars">
       <HintPath>..\packages\Handlebars.Net.1.7.0\lib\Handlebars.dll</HintPath>
     </Reference>
+    <Reference Include="System.Net.Http">
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="Microsoft.Threading.Tasks">
+      <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions">
+      <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop">
+      <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net" />
     <Reference Include="System.Net.Http.Primitives">
       <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http.Extensions">
       <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net.Http">
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="crypto">
       <HintPath>..\packages\Portable.BouncyCastle-Signed.1.7.0.2\lib\portable-net45+dnxcore50+wp80+win+wpa81+MonoTouch10+MonoAndroid10+xamarinmac20+xamarinios10\crypto.dll</HintPath>
     </Reference>
-    <Reference Include="ConcurrentHashtable">
-      <HintPath>..\packages\PubnubPCL.3.7.0.1\lib\portable-net40+sl50+win+wp80+MonoAndroid10+xamarinios10+MonoTouch10\ConcurrentHashtable.dll</HintPath>
-    </Reference>
     <Reference Include="PubNub-Messaging">
-      <HintPath>..\packages\PubnubPCL.3.7.0.1\lib\portable-net40+sl50+win+wp80+MonoAndroid10+xamarinios10+MonoTouch10\PubNub-Messaging.dll</HintPath>
-    </Reference>
-    <Reference Include="Mono.Security">
-      <HintPath>..\packages\Mono.Security.3.2.3.0\lib\net45\Mono.Security.dll</HintPath>
-    </Reference>
-    <Reference Include="Validation">
-      <HintPath>..\packages\Validation.2.0.6.15003\lib\portable-net40+sl50+win+wpa81+wp80+Xamarin.iOS10+MonoAndroid10+MonoTouch10\Validation.dll</HintPath>
-    </Reference>
-    <Reference Include="PCLCrypto">
-      <HintPath>..\packages\PCLCrypto.1.0.86\lib\net40-Client\PCLCrypto.dll</HintPath>
+      <HintPath>..\packages\PubnubPCL.3.7.5.0\lib\portable-net40+sl50+win+wp80+MonoAndroid10+xamarinios10+MonoTouch10\PubNub-Messaging.dll</HintPath>
     </Reference>
     <Reference Include="RingCentral">
-      <HintPath>..\packages\RingCentralSDK.0.1.21\lib\net45\RingCentral.dll</HintPath>
+      <HintPath>..\packages\RingCentralSDK.1.0.0-alpha2\lib\net45\RingCentral.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/csharp/csharp/packages.config
+++ b/csharp/csharp/packages.config
@@ -3,15 +3,13 @@
   <package id="DotEnv" version="0.0.1.1" targetFramework="net45" />
   <package id="Handlebars.Net" version="1.7.0" targetFramework="net45" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
+  <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net45" />
-  <package id="Mono.Security" version="3.2.3.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
-  <package id="PCLCrypto" version="1.0.86" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
   <package id="Portable.BouncyCastle-Signed" version="1.7.0.2" targetFramework="net45" />
-  <package id="PubnubPCL" version="3.7.0.1" targetFramework="net45" />
-  <package id="RingCentralSDK" version="0.1.21" targetFramework="net45" />
+  <package id="PubnubPCL" version="3.7.5.0" targetFramework="net45" />
+  <package id="RingCentralSDK" version="1.0.0-alpha2" targetFramework="net45" />
   <package id="SimpleJson" version="0.38.0" targetFramework="net45" />
   <package id="System.IO.Abstractions" version="1.4.0.86" targetFramework="net45" />
-  <package id="Validation" version="2.0.6.15003" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
The csharp demo runs pretty well on Windows. But an exception was thrown when running on Mac:

```
System.ArgumentException: boundary.
```

Inspired by this [Stackoverflow thread](http://stackoverflow.com/questions/29075414/system-argumentexception-when-uploading-multipart). I finally figured out the root cause and fixed it:  https://github.com/ringcentral/ringcentral-csharp/commit/3cceffcaa4929fd8f3976b3ec0115edd96189514

The root cause is Mono on Mac doesn't like the hard-coded boundary string: `Boundary_1_14413901_1361871080888`. It thinks that this boundary string is invalid so it throws `System.ArgumentException`.  I fixed it by removing the hard-coded boundary string. Let it generate a dynamic boundary string is way better.

Let's release C# SDK 1.0.0-alpha2 as soon as possible. Currently I host it locally.
